### PR TITLE
Update the port to 5005 to match the new ports the backend uses

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -7,20 +7,20 @@ export default defineConfig({
   server: {
     open: true,
 
-    // proxy API requests to the propermesh backend server which runs at port 5000 when running locally
+    // proxy API requests to the propermesh backend server which runs at port 5005 when running locally
     proxy: {
       "/api": {
-        target: "http://localhost:5000",
+        target: "http://localhost:5005",
       },
       "/auth": {
-        target: "http://localhost:5000",
+        target: "http://localhost:5005",
       },
       // NOTE: /docs and /openapi.json are for loading the openapi API docs from the backend server
       "/docs": {
-        target: "http://localhost:5000",
+        target: "http://localhost:5005",
       },
       "/openapi.json": {
-        target: "http://localhost:5000",
+        target: "http://localhost:5005",
       },
     },
   },


### PR DESCRIPTION
I switched from 5000 -> 5005 because MacOS runs a program on port 5000 so now we just wont have to deal with that overlapping port number

@ErikAmerico I updated the backend to run at port 5005 instead of 5000 so I'm updating the proxy of the frontend so it uses the new ports