### PR TITLE
Fix logo loading in production

### DIFF
--- a/src/components/landing/landingPage.css
+++ b/src/components/landing/landingPage.css
@@ -22,7 +22,7 @@ body {
   position: absolute;
   top: 0;
   background-size: 200% 100%;
-  background-image: url("assets/logo.png");
+  background-image: url("/assets/logo.png");
   transition: transform 1s ease-out;
 }
 


### PR DESCRIPTION
This fixes the logo in production and still works in development mode. Before this change it was trying to load /assets/assets/logo.png in the production deployment

@ErikAmerico Im going to mark you as a reviewer on all PRs that I make in propermesh-view so feel free to drop a review if you have any feedback or questions or anything but also you don't have to make any comments if you dont have anything