### PR TITLE
Keep header at top

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,8 @@ function App() {
   const location = useLocation();
   const contentRef = useRef(null);
   const [isStickyFooter, setIsStickyFooter] = useState(false);
+  const headerRef = useRef(null);
+  const [headerHeight, setHeaderHeight] = useState(0);
 
   useEffect(() => {
     const contentHeight = contentRef.current.getBoundingClientRect().height;
@@ -19,11 +21,15 @@ function App() {
     setIsStickyFooter(contentHeight < viewportHeight);
   }, [location.pathname]); // Rerun this effect if the route changes
 
+  useEffect(() => {
+    setHeaderHeight(headerRef.current.offsetHeight);
+  }, []);
+
   return (
     <AuthProvider>
       <>
-        <Header />
-        <div ref={contentRef}>
+        <Header ref={headerRef} />
+        <div ref={contentRef} style={{ marginTop: `${headerHeight}px` }}>
           <Outlet />
         </div>
         <Footer sticky={isStickyFooter} />

--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -8,7 +8,6 @@ import { useEffect, forwardRef } from "react";
 const Header = forwardRef((props, ref) => {
   const navigate = useNavigate();
   const { confirmLogin, isLoggedIn, setIsLoggedIn } = useAuth();
-  console.log("hey bitfch");
 
   useEffect(() => {
     confirmLogin();

--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -2,11 +2,13 @@ import { Menu } from "antd";
 import { useNavigate } from "react-router-dom";
 import "./header.css";
 import { useAuth } from "../../utils/useAuth";
-import { useEffect } from "react";
+import { useEffect, forwardRef } from "react";
 
-const Header = () => {
+//Even though "props" is not used, react expects that it be passed in
+const Header = forwardRef((props, ref) => {
   const navigate = useNavigate();
   const { confirmLogin, isLoggedIn, setIsLoggedIn } = useAuth();
+  console.log("hey bitfch");
 
   useEffect(() => {
     confirmLogin();
@@ -62,13 +64,9 @@ const Header = () => {
       ];
 
   return (
-    <div className="header-container">
+    <div ref={ref} className="header-container">
       <div className="header-logo-title" onClick={() => navigate("/")}>
-        <img
-          src="/assets/favicon.png"
-          alt="logo-in-header"
-          id="header-logo"
-        />
+        <img src="/assets/favicon.png" alt="logo-in-header" id="header-logo" />
         <div className="header-title">Propermesh</div>
       </div>
       <Menu
@@ -79,6 +77,10 @@ const Header = () => {
       />
     </div>
   );
-};
+});
+
+//This is a way to give the component a display name for debugging purposes
+//Apparently without it, It would be difficult to determine which component is causing an error
+Header.displayName = "Header";
 
 export default Header;

--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -36,6 +36,10 @@
   font-weight: bold;
 }
 
+.ant-menu-horizontal {
+  border-bottom: none;
+}
+
 .ant-menu-horizontal .ant-menu-item-selected,
 .ant-menu-horizontal .ant-menu-item-selected:hover,
 .ant-menu-horizontal .ant-menu-item-selected::after,

--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -1,4 +1,9 @@
 .header-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 1000;
   display: flex;
   justify-content: space-between;
   align-items: center;


### PR DESCRIPTION
I tried a more simple approach, But was getting mixed results on different screen sizes. 


In app.jsx

`const headerRef = useRef(null);`

is passed to `<Header ref={headerRef} />`

Because the Header component is wrapped with forwardRef, it receives this prop as the second argument (idk why it automatically does that).

It then updates headerRef.current and adjusts the layout of the rest of the page to match the bottom of the header