### PR TITLE
Units selector

### DIFF
--- a/src/components/AnalysisPage/AnalysisPage.jsx
+++ b/src/components/AnalysisPage/AnalysisPage.jsx
@@ -6,14 +6,18 @@ import UnitsSelector from "./UnitsSelector/UnitsSelector";
 
 const AnalysisPage = () => {
   const [fileFor3dModel, setFileFor3dModel] = useState(null);
+  const [partId, setPartId] = useState(null);
 
   return (
     <div>
       <h1 style={{ fontFamily: '"Roboto", sans-serif' }}>Analysis Page</h1>
       <UploadPartButton setFileFor3dModel={setFileFor3dModel} />
-      <ViewPartsButton setFileFor3dModel={setFileFor3dModel} />
+      <ViewPartsButton
+        setFileFor3dModel={setFileFor3dModel}
+        setPartId={setPartId}
+      />
       <ModelViewer fileFor3dModel={fileFor3dModel} />
-      <UnitsSelector fileFor3dModel={fileFor3dModel} />
+      <UnitsSelector partId={partId} />
     </div>
   );
 };

--- a/src/components/AnalysisPage/AnalysisPage.jsx
+++ b/src/components/AnalysisPage/AnalysisPage.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import UploadPartButton from "./UploadPartButton/UploadPartButton";
 import ViewPartsButton from "./ViewPartsButton/ViewPartsButton";
 import ModelViewer from "./3dModelViewer/3dModelViewer";
+import UnitsSelector from "./UnitsSelector/UnitsSelector";
 
 const AnalysisPage = () => {
   const [fileFor3dModel, setFileFor3dModel] = useState(null);
@@ -12,6 +13,7 @@ const AnalysisPage = () => {
       <UploadPartButton setFileFor3dModel={setFileFor3dModel} />
       <ViewPartsButton setFileFor3dModel={setFileFor3dModel} />
       <ModelViewer fileFor3dModel={fileFor3dModel} />
+      <UnitsSelector fileFor3dModel={fileFor3dModel} />
     </div>
   );
 };

--- a/src/components/AnalysisPage/AnalysisPage.jsx
+++ b/src/components/AnalysisPage/AnalysisPage.jsx
@@ -11,7 +11,10 @@ const AnalysisPage = () => {
   return (
     <div>
       <h1 style={{ fontFamily: '"Roboto", sans-serif' }}>Analysis Page</h1>
-      <UploadPartButton setFileFor3dModel={setFileFor3dModel} />
+      <UploadPartButton
+        setFileFor3dModel={setFileFor3dModel}
+        setPartId={setPartId}
+      />
       <ViewPartsButton
         setFileFor3dModel={setFileFor3dModel}
         setPartId={setPartId}

--- a/src/components/AnalysisPage/UnitsSelector/UnitsSelector.jsx
+++ b/src/components/AnalysisPage/UnitsSelector/UnitsSelector.jsx
@@ -4,6 +4,7 @@ import { CheckCircleOutlined } from "@ant-design/icons";
 import "./unitsSelector.css";
 import PropTypes from "prop-types";
 import { updatePartUnits } from "./updatePartUnits";
+import { getPartData } from "./getPartData";
 
 const UnitsSelector = ({ partId }) => {
   const [units, setUnits] = useState(undefined);
@@ -13,11 +14,7 @@ const UnitsSelector = ({ partId }) => {
     const getCurrentUnits = async () => {
       if (partId) {
         try {
-          const response = await fetch(`/api/v0/parts/${partId}`);
-          if (!response.ok) {
-            throw new Error("Failed to get part data.");
-          }
-          const data = await response.json();
+          const data = await getPartData(partId);
           setUnits(data.units);
         } catch (error) {
           console.error("Error getting part data:", error);

--- a/src/components/AnalysisPage/UnitsSelector/UnitsSelector.jsx
+++ b/src/components/AnalysisPage/UnitsSelector/UnitsSelector.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Select, Space } from "antd";
 import { CheckCircleOutlined } from "@ant-design/icons";
 import "./unitsSelector.css";
@@ -7,6 +7,25 @@ import PropTypes from "prop-types";
 const UnitsSelector = ({ partId }) => {
   const [units, setUnits] = useState(undefined);
   const [showSuccess, setShowSuccess] = useState(false);
+
+  useEffect(() => {
+    const getCurrentUnits = async () => {
+      if (partId) {
+        try {
+          const response = await fetch(`/api/v0/parts/${partId}`);
+          if (!response.ok) {
+            throw new Error("Failed to get part data.");
+          }
+          const data = await response.json();
+          setUnits(data.units);
+        } catch (error) {
+          console.error("Error getting part data:", error);
+        }
+      }
+    };
+
+    getCurrentUnits();
+  }, [partId]);
 
   const handleChange = async (value) => {
     setUnits(value);
@@ -41,7 +60,7 @@ const UnitsSelector = ({ partId }) => {
         <span id="units-selector-label">Units: </span>
         <Select
           placeholder="Select units"
-          defaultValue={units}
+          value={units}
           style={{ width: 120 }}
           onChange={handleChange}
           options={[

--- a/src/components/AnalysisPage/UnitsSelector/UnitsSelector.jsx
+++ b/src/components/AnalysisPage/UnitsSelector/UnitsSelector.jsx
@@ -3,6 +3,7 @@ import { Select, Space, Tooltip, Modal } from "antd";
 import { CheckCircleOutlined } from "@ant-design/icons";
 import "./unitsSelector.css";
 import PropTypes from "prop-types";
+import { updatePartUnits } from "./updatePartUnits";
 
 const UnitsSelector = ({ partId }) => {
   const [units, setUnits] = useState(undefined);
@@ -30,20 +31,7 @@ const UnitsSelector = ({ partId }) => {
   const handleChange = async (value) => {
     setUnits(value);
     try {
-      const response = await fetch(`/api/v0/parts/${partId}/units`, {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ units: value }),
-      });
-
-      if (!response.ok) {
-        throw new Error("Failed to update units.");
-      }
-
-      const data = await response.json();
-      console.log(data);
+      await updatePartUnits(partId, value);
 
       setShowSuccess(true);
       setTimeout(() => {

--- a/src/components/AnalysisPage/UnitsSelector/UnitsSelector.jsx
+++ b/src/components/AnalysisPage/UnitsSelector/UnitsSelector.jsx
@@ -1,20 +1,43 @@
 import { useState } from "react";
 import { Select, Space } from "antd";
+import { CheckCircleOutlined } from "@ant-design/icons";
 import "./unitsSelector.css";
 import PropTypes from "prop-types";
 
 const UnitsSelector = ({ partId }) => {
   const [units, setUnits] = useState(undefined);
-  console.log("partId: ", partId);
+  const [showSuccess, setShowSuccess] = useState(false);
 
-  const handleChange = (value) => {
+  const handleChange = async (value) => {
     setUnits(value);
-    console.log(`selected ${value}`);
+    try {
+      const response = await fetch(`/api/v0/parts/${partId}/units`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ units: value }),
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to update units.");
+      }
+
+      const data = await response.json();
+      console.log(data);
+
+      setShowSuccess(true);
+      setTimeout(() => {
+        setShowSuccess(false);
+      }, 2000);
+    } catch (error) {
+      console.error("Error updating units:", error);
+    }
   };
 
   return (
-    <div>
-      <Space wrap>
+    <Space wrap>
+      <div id="select-container">
         <span id="units-selector-label">Units: </span>
         <Select
           placeholder="Select units"
@@ -26,8 +49,14 @@ const UnitsSelector = ({ partId }) => {
             { value: "inches", label: "inches" },
           ]}
         />
-      </Space>
-    </div>
+        {showSuccess && (
+          <CheckCircleOutlined
+            style={{ color: "green", fontSize: "16px" }}
+            id="unit-update-success-icon"
+          />
+        )}
+      </div>
+    </Space>
   );
 };
 

--- a/src/components/AnalysisPage/UnitsSelector/UnitsSelector.jsx
+++ b/src/components/AnalysisPage/UnitsSelector/UnitsSelector.jsx
@@ -26,14 +26,10 @@ const UnitsSelector = ({ partId }) => {
   }, [partId]);
 
   const handleChange = async (value) => {
-    // keep track of what the value was before this change so that if an error happens; the value in
-    // the selector can go back to what it was before the error
-    const previousValue = units
-
-    setUnits(value);
     try {
       await updatePartUnits(partId, value);
 
+      setUnits(value);
       setShowSuccess(true);
       setTimeout(() => {
         setShowSuccess(false);
@@ -48,9 +44,6 @@ const UnitsSelector = ({ partId }) => {
         duration: 4.5,
         style: { width: 300 },
       });
-
-      // Reset the selector to what it previously was so they know their change didnt work
-      setUnits(previousValue)
     }
   };
 

--- a/src/components/AnalysisPage/UnitsSelector/UnitsSelector.jsx
+++ b/src/components/AnalysisPage/UnitsSelector/UnitsSelector.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Select, Space, Tooltip } from "antd";
+import { Select, Space, Tooltip, Modal } from "antd";
 import { CheckCircleOutlined } from "@ant-design/icons";
 import "./unitsSelector.css";
 import PropTypes from "prop-types";
@@ -51,6 +51,11 @@ const UnitsSelector = ({ partId }) => {
       }, 2000);
     } catch (error) {
       console.error("Error updating units:", error);
+      Modal.error({
+        title: "Failed to Update Units",
+        content: <span style={{ fontSize: "24px" }}>🫤</span>,
+        centered: true,
+      });
     }
   };
 

--- a/src/components/AnalysisPage/UnitsSelector/UnitsSelector.jsx
+++ b/src/components/AnalysisPage/UnitsSelector/UnitsSelector.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
-import { Select, Space, Tooltip, Modal } from "antd";
-import { CheckCircleOutlined } from "@ant-design/icons";
+import { Select, Space, Tooltip, notification } from "antd";
+import { CheckCircleOutlined, ExclamationCircleTwoTone } from "@ant-design/icons";
 import "./unitsSelector.css";
 import PropTypes from "prop-types";
 import { updatePartUnits } from "./updatePartUnits";
@@ -26,6 +26,10 @@ const UnitsSelector = ({ partId }) => {
   }, [partId]);
 
   const handleChange = async (value) => {
+    // keep track of what the value was before this change so that if an error happens; the value in
+    // the selector can go back to what it was before the error
+    const previousValue = units
+
     setUnits(value);
     try {
       await updatePartUnits(partId, value);
@@ -36,11 +40,17 @@ const UnitsSelector = ({ partId }) => {
       }, 2000);
     } catch (error) {
       console.error("Error updating units:", error);
-      Modal.error({
-        title: "Failed to Update Units",
-        content: <span style={{ fontSize: "24px" }}>🫤</span>,
-        centered: true,
+      notification.error({
+        message: "Failed to update units",
+        description: "Try again in a few minutes. Report the error to ryan@propermesh.com if the problem persists.",
+        icon: <ExclamationCircleTwoTone twoToneColor="#eb2f96" />,
+        placement: "top",
+        duration: 4.5,
+        style: { width: 300 },
       });
+
+      // Reset the selector to what it previously was so they know their change didnt work
+      setUnits(previousValue)
     }
   };
 

--- a/src/components/AnalysisPage/UnitsSelector/UnitsSelector.jsx
+++ b/src/components/AnalysisPage/UnitsSelector/UnitsSelector.jsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
 import { Select, Space } from "antd";
 import "./unitsSelector.css";
+import PropTypes from "prop-types";
 
-const UnitsSelector = () => {
+const UnitsSelector = ({ partId }) => {
   const [units, setUnits] = useState(undefined);
+  console.log("partId: ", partId);
 
   const handleChange = (value) => {
     setUnits(value);
@@ -27,6 +29,10 @@ const UnitsSelector = () => {
       </Space>
     </div>
   );
+};
+
+UnitsSelector.propTypes = {
+  partId: PropTypes.string,
 };
 
 export default UnitsSelector;

--- a/src/components/AnalysisPage/UnitsSelector/UnitsSelector.jsx
+++ b/src/components/AnalysisPage/UnitsSelector/UnitsSelector.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Select, Space } from "antd";
+import { Select, Space, Tooltip } from "antd";
 import { CheckCircleOutlined } from "@ant-design/icons";
 import "./unitsSelector.css";
 import PropTypes from "prop-types";
@@ -54,20 +54,28 @@ const UnitsSelector = ({ partId }) => {
     }
   };
 
+  const isDisabled = !partId;
+  const tooltipTitle = partId
+    ? ""
+    : "View or upload a part to the viewer before selecting a unit of measurement.";
+
   return (
     <Space wrap>
       <div id="select-container">
         <span id="units-selector-label">Units: </span>
-        <Select
-          placeholder="Select units"
-          value={units}
-          style={{ width: 120 }}
-          onChange={handleChange}
-          options={[
-            { value: "mm", label: "mm" },
-            { value: "inches", label: "inches" },
-          ]}
-        />
+        <Tooltip title={tooltipTitle} placement="top">
+          <Select
+            placeholder="Select units"
+            value={units}
+            style={{ width: 120 }}
+            onChange={handleChange}
+            disabled={isDisabled}
+            options={[
+              { value: "mm", label: "mm" },
+              { value: "inches", label: "inches" },
+            ]}
+          />
+        </Tooltip>
         {showSuccess && (
           <CheckCircleOutlined
             style={{ color: "green", fontSize: "16px" }}

--- a/src/components/AnalysisPage/UnitsSelector/UnitsSelector.jsx
+++ b/src/components/AnalysisPage/UnitsSelector/UnitsSelector.jsx
@@ -61,7 +61,7 @@ const UnitsSelector = ({ partId }) => {
 
   return (
     <Space wrap>
-      <div id="select-container">
+      <div id="select-container" className={!isDisabled ? "enabledSelect" : ""}>
         <span id="units-selector-label">Units: </span>
         <Tooltip title={tooltipTitle} placement="top">
           <Select

--- a/src/components/AnalysisPage/UnitsSelector/UnitsSelector.jsx
+++ b/src/components/AnalysisPage/UnitsSelector/UnitsSelector.jsx
@@ -1,0 +1,32 @@
+import { useState } from "react";
+import { Select, Space } from "antd";
+import "./unitsSelector.css";
+
+const UnitsSelector = () => {
+  const [units, setUnits] = useState(undefined);
+
+  const handleChange = (value) => {
+    setUnits(value);
+    console.log(`selected ${value}`);
+  };
+
+  return (
+    <div>
+      <Space wrap>
+        <span id="units-selector-label">Units: </span>
+        <Select
+          placeholder="Select units"
+          defaultValue={units}
+          style={{ width: 120 }}
+          onChange={handleChange}
+          options={[
+            { value: "mm", label: "mm" },
+            { value: "inches", label: "inches" },
+          ]}
+        />
+      </Space>
+    </div>
+  );
+};
+
+export default UnitsSelector;

--- a/src/components/AnalysisPage/UnitsSelector/getPartData.js
+++ b/src/components/AnalysisPage/UnitsSelector/getPartData.js
@@ -1,0 +1,10 @@
+export const getPartData = async (partId) => {
+  const response = await fetch(`/api/v0/parts/${partId}`);
+
+  if (!response.ok) {
+    throw new Error("Failed to get part data.");
+  }
+
+  const data = await response.json();
+  return data;
+};

--- a/src/components/AnalysisPage/UnitsSelector/unitsSelector.css
+++ b/src/components/AnalysisPage/UnitsSelector/unitsSelector.css
@@ -1,0 +1,4 @@
+#units-selector-label {
+  font-family: "Roboto", sans-serif;
+  font-size: larger;
+}

--- a/src/components/AnalysisPage/UnitsSelector/unitsSelector.css
+++ b/src/components/AnalysisPage/UnitsSelector/unitsSelector.css
@@ -2,3 +2,23 @@
   font-family: "Roboto", sans-serif;
   font-size: larger;
 }
+
+#select-container {
+  position: relative;
+  display: inline-block;
+}
+
+#unit-update-success-icon {
+  position: absolute;
+  animation: fadeInOut 2s;
+}
+
+@keyframes fadeInOut {
+  0%,
+  100% {
+    opacity: 0;
+  }
+  50% {
+    opacity: 1;
+  }
+}

--- a/src/components/AnalysisPage/UnitsSelector/unitsSelector.css
+++ b/src/components/AnalysisPage/UnitsSelector/unitsSelector.css
@@ -13,6 +13,10 @@
   animation: fadeInOut 2s;
 }
 
+.enabledSelect .ant-select-selection-placeholder {
+  color: black !important;
+}
+
 @keyframes fadeInOut {
   0%,
   100% {

--- a/src/components/AnalysisPage/UnitsSelector/updatePartUnits.js
+++ b/src/components/AnalysisPage/UnitsSelector/updatePartUnits.js
@@ -1,21 +1,16 @@
 export const updatePartUnits = async (partId, units) => {
-  try {
-    const response = await fetch(`/api/v0/parts/${partId}/units`, {
-      method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ units }),
-    });
+  const response = await fetch(`/api/v0/parts/${partId}/units`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ units }),
+  });
 
-    if (!response.ok) {
-      throw new Error("Failed to update units.");
-    }
-
-    const data = await response.json();
-    return data;
-  } catch (error) {
-    console.error("Error updating units:", error);
-    throw error;
+  if (!response.ok) {
+    throw new Error("Failed to update units.");
   }
+
+  const data = await response.json();
+  return data;
 };

--- a/src/components/AnalysisPage/UnitsSelector/updatePartUnits.js
+++ b/src/components/AnalysisPage/UnitsSelector/updatePartUnits.js
@@ -1,0 +1,21 @@
+export const updatePartUnits = async (partId, units) => {
+  try {
+    const response = await fetch(`/api/v0/parts/${partId}/units`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ units }),
+    });
+
+    if (!response.ok) {
+      throw new Error("Failed to update units.");
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error("Error updating units:", error);
+    throw error;
+  }
+};

--- a/src/components/AnalysisPage/UploadPartButton/UploadPartButton.jsx
+++ b/src/components/AnalysisPage/UploadPartButton/UploadPartButton.jsx
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 
 const { Dragger } = Upload;
 
-const UploadPartButton = ({ setFileFor3dModel }) => {
+const UploadPartButton = ({ setFileFor3dModel, setPartId }) => {
   const [isUploadAllowed, setIsUploadAllowed] = useState(true);
 
   const acceptedFileTypes = [".stl", ".obj", ".ply", ".gltf", ".glb", ".3mf"];
@@ -28,6 +28,7 @@ const UploadPartButton = ({ setFileFor3dModel }) => {
       }
       if (status === "done") {
         message.success(`${info.file.name} file uploaded successfully.`);
+        setPartId(info.file.response.id);
       } else if (status === "error") {
         message.error(`${info.file.name} file upload failed.`);
       }
@@ -78,6 +79,7 @@ const UploadPartButton = ({ setFileFor3dModel }) => {
 
 UploadPartButton.propTypes = {
   setFileFor3dModel: PropTypes.func,
+  setPartId: PropTypes.func,
 };
 
 export default UploadPartButton;

--- a/src/components/AnalysisPage/ViewPartsButton/ViewPartsButton.jsx
+++ b/src/components/AnalysisPage/ViewPartsButton/ViewPartsButton.jsx
@@ -4,7 +4,7 @@ import { DownloadOutlined } from "@ant-design/icons";
 import PropTypes from "prop-types";
 import { downloadBlobToLocalMachine } from "./downloadBlob";
 
-const ViewPartsButton = ({ setFileFor3dModel }) => {
+const ViewPartsButton = ({ setFileFor3dModel, setPartId }) => {
   const [modalOpen, setModalOpen] = useState(false);
   const [partsData, setPartsData] = useState([]);
   const [fileNameForUpload, setFileNameForUpload] = useState("");
@@ -80,6 +80,7 @@ const ViewPartsButton = ({ setFileFor3dModel }) => {
                   setModalOpen(false);
                   downloadPartFileAndPlaceIn3dViewer(part.id);
                   setFileNameForUpload(part.name);
+                  setPartId(part.id);
                 }}
                 className="part-list-item-row"
               >
@@ -99,6 +100,7 @@ const ViewPartsButton = ({ setFileFor3dModel }) => {
 
 ViewPartsButton.propTypes = {
   setFileFor3dModel: PropTypes.func,
+  setPartId: PropTypes.func,
 };
 
 export default ViewPartsButton;


### PR DESCRIPTION
When a part is loaded into the viewer

The user can select `mm` or `inches` as the unit measurement, updating the db.

If a part already has units defined, those are shown by default and can be still be updated.

If a part hasn't been loaded then the user can't select a unit of measurement and there is a toolTip that explains why they can't view the select dropdown. 