### PR TITLE
fix units selection bug

### DIFF
--- a/src/components/AnalysisPage/AnalysisPage.jsx
+++ b/src/components/AnalysisPage/AnalysisPage.jsx
@@ -55,6 +55,7 @@ const AnalysisPage = () => {
             <UploadPartButton
               setFileFor3dModel={setFileFor3dModel}
               setPartId={setPartId}
+              setUnits={setUnits}
             />
           </div>
         </Col>

--- a/src/components/AnalysisPage/UploadPartButton/UploadPartButton.jsx
+++ b/src/components/AnalysisPage/UploadPartButton/UploadPartButton.jsx
@@ -6,7 +6,7 @@ import "./uploadPartButton.css";
 
 const { Dragger } = Upload;
 
-const UploadPartButton = ({ setFileFor3dModel, setPartId }) => {
+const UploadPartButton = ({ setFileFor3dModel, setPartId, setUnits }) => {
   const [isUploadAllowed, setIsUploadAllowed] = useState(true);
 
   const acceptedFileTypes = [".stl", ".obj", ".ply", ".gltf", ".glb", ".3mf"];
@@ -30,6 +30,7 @@ const UploadPartButton = ({ setFileFor3dModel, setPartId }) => {
       if (status === "done") {
         message.success(`${info.file.name} file uploaded successfully.`);
         setPartId(info.file.response.id);
+        setUnits(null);
       } else if (status === "error") {
         message.error(`${info.file.name} file upload failed.`);
       }
@@ -81,6 +82,7 @@ const UploadPartButton = ({ setFileFor3dModel, setPartId }) => {
 UploadPartButton.propTypes = {
   setFileFor3dModel: PropTypes.func,
   setPartId: PropTypes.func,
+  setUnits: PropTypes.func,
 };
 
 export default UploadPartButton;

--- a/src/components/AnalysisPage/ViewPartsButton/ViewPartsButton.jsx
+++ b/src/components/AnalysisPage/ViewPartsButton/ViewPartsButton.jsx
@@ -28,6 +28,8 @@ const ViewPartsButton = ({
         }
         if (data.units) {
           setUnits(data.units);
+        } else {
+          setUnits(null);
         }
       });
   };


### PR DESCRIPTION
When you uploaded a new part, the units selector would still have the value of the previous part.
Same issue for when viewing a part that hadn't had a unit selected yet, It would show the units for the previous part. 
So it looked like you could run a thickness analysis but it would fail because you didn't actually select anything. 

My watch is showing some A.M hours, so this might not have been the best way to go about this, let me know if you have a better solution!