### PR TITLE
Prep for deploy

### DIFF
--- a/src/components/AnalysisPage/UploadPartButton/UploadPartButton.jsx
+++ b/src/components/AnalysisPage/UploadPartButton/UploadPartButton.jsx
@@ -9,7 +9,11 @@ const { Dragger } = Upload;
 const UploadPartButton = ({ setFileFor3dModel, setPartId, setUnits }) => {
   const [isUploadAllowed, setIsUploadAllowed] = useState(true);
 
-  const acceptedFileTypes = [".stl", ".obj", ".ply", ".gltf", ".glb", ".3mf"];
+  // These are the file types the backend can handle... but we only support stl in the
+  // frontend viewer right now so once we solve the support on the frontend we can go back
+  // to this list
+  // const acceptedFileTypes = [".stl", ".obj", ".ply", ".gltf", ".glb", ".3mf"];
+  const acceptedFileTypes = [".stl"];
 
   const props = {
     name: "file",
@@ -74,7 +78,13 @@ const UploadPartButton = ({ setFileFor3dModel, setPartId, setUnits }) => {
           Click or drag file to this area to upload
         </p>
         <p className="ant-upload-hint">
-          Accepted file types: .stl .obj .ply .gltf .glb .3mf
+          {/*
+            // These are the file types the backend can handle... but we only support stl in the
+            // frontend viewer right now so once we solve the support on the frontend we can go back
+            // to this list
+            Accepted file types: .stl .obj .ply .gltf .glb .3mf
+          */}
+          Accepted file type: .stl
         </p>
       </Dragger>
     </div>

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -51,12 +51,10 @@ const Header = forwardRef((props, ref) => {
         },
       ]
     : [
-        // TODO: dont show the login button until I actually build out features that you can access
-        // once you're logged in -Ryan
-        //{
-        //  label: "Login",
-        //  key: "login",
-        //},
+        {
+          label: "Login",
+          key: "login",
+        },
         {
           label: "API Docs",
           key: "apiDocs",

--- a/src/components/LandingPage/LandingPage.jsx
+++ b/src/components/LandingPage/LandingPage.jsx
@@ -1,18 +1,20 @@
 import "./landingPage.css";
 import { Row, Col, Button, message } from "antd";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../../utils/useAuth";
 
 export default function LandingPage() {
   const [messageApi, contextHolder] = message.useMessage();
-  const analysisComingSoon = () => {
-    messageApi.open({
-      type: "info",
-      content: "Interactive Analysis Page Coming Soon!",
-      className: "coming-soon-message",
-      style: {
-        marginTop: "30vh",
-      },
-    });
-  };
+  const navigate = useNavigate();
+  const { isLoggedIn } = useAuth();
+
+  function navigateToAnalysPageBasedOnLoginStatus() {
+    if (isLoggedIn) {
+      navigate("/analysis")
+    } else {
+      navigate("/login")
+    }
+  }
 
   return (
     <div className="App">
@@ -49,7 +51,7 @@ export default function LandingPage() {
             type="primary"
             id="analysis-page-btn"
             size="large"
-            onClick={analysisComingSoon}
+            onClick={navigateToAnalysPageBasedOnLoginStatus}
           >
             Analyze Parts
           </Button>

--- a/src/components/LandingPage/LandingPage.jsx
+++ b/src/components/LandingPage/LandingPage.jsx
@@ -1,10 +1,9 @@
 import "./landingPage.css";
-import { Row, Col, Button, message } from "antd";
+import { Row, Col, Button } from "antd";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../../utils/useAuth";
 
 export default function LandingPage() {
-  const [messageApi, contextHolder] = message.useMessage();
   const navigate = useNavigate();
   const { isLoggedIn } = useAuth();
 
@@ -46,7 +45,6 @@ export default function LandingPage() {
               </li>
             </ul>
           </div>
-          {contextHolder}
           <Button
             type="primary"
             id="analysis-page-btn"

--- a/src/components/LandingPage/LandingPage.jsx
+++ b/src/components/LandingPage/LandingPage.jsx
@@ -33,8 +33,6 @@ export default function LandingPage() {
           </div>
           <div id="description-list">
             <ul>
-              {/* I commented this out incase you wanted to deploy the redesign in the meantime :) */}
-              {/* <li>TODO</li> */}
               <li>
                 Many mesh and CAD file types supported such as stl, obj, ply,
                 STEP, SLDPRT and more


### PR DESCRIPTION
Some quick changes to support the deployment of the analysis page in its current state

- Expose the login item in the header menu
- Only allow .stl files
- Update the 'Analyze Parts' button to navigate to the analysis page